### PR TITLE
feat: remove baseURL from hugo config

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,3 @@
-baseURL = "https://deepin-community.github.io/planet/"
 languageCode = "zh-cn"
 defaultContentLanguage = "zh-cn"
 title = "Planet deepin"


### PR DESCRIPTION
删除配置文件的baseURl,便于部署到自定义域名